### PR TITLE
キャビネットで更新日をunsetさせない、移行でウィジウィグのTABLEタグにtable-hoverは不要

### DIFF
--- a/Model/Behavior/Nc2ToNc3CabinetBehavior.php
+++ b/Model/Behavior/Nc2ToNc3CabinetBehavior.php
@@ -206,6 +206,8 @@ class Nc2ToNc3CabinetBehavior extends Nc2ToNc3BaseBehavior {
 				// 新着用に更新日を移行
 				// @see https://github.com/NetCommons3/Topics/blob/3.1.0/Model/Behavior/TopicsBaseBehavior.php#L146
 				'modified' => $this->_convertDate($nc2CabinetFile['Nc2CabinetFile']['update_time']),
+				// キャビネットで更新日をunsetさせない
+				'_is_no_unset_modified' => 1,
 			];
 			//フォルダの場合
 		} else {
@@ -221,6 +223,8 @@ class Nc2ToNc3CabinetBehavior extends Nc2ToNc3BaseBehavior {
 				// 新着用に更新日を移行
 				// @see https://github.com/NetCommons3/Topics/blob/3.1.0/Model/Behavior/TopicsBaseBehavior.php#L146
 				'modified' => $this->_convertDate($nc2CabinetFile['Nc2CabinetFile']['update_time']),
+				// キャビネットで更新日をunsetさせない
+				'_is_no_unset_modified' => 1,
 			];
 		}
 		$data['Block'] = [

--- a/Model/Behavior/Nc2ToNc3WysiwygBehavior.php
+++ b/Model/Behavior/Nc2ToNc3WysiwygBehavior.php
@@ -393,7 +393,7 @@ class Nc2ToNc3WysiwygBehavior extends Nc2ToNc3BaseBehavior {
 		// <table>のstyleをclassに置き換え
 		$patterns[] = [
 			'pattern' => '/<table.*? (style=".*?")>/',
-			'replace' => 'class="table table-bordered table-hover table-responsive"'
+			'replace' => 'class="table table-bordered table-responsive"'
 		];
 		// <tr><td>のstyle消す
 		//		$patterns[] = [


### PR DESCRIPTION
* キャビネットで更新日をunsetさせない
https://github.com/NetCommons3/NetCommons3/issues/1076

問題なければ２，３日中にマーチしようと思ってます。