### PR TITLE
fix: リンクリストの移行時、4件中3件までしか移行されないバグの修正（後続プラグイン移行で$BlocksLanguage->create()忘れ）

### DIFF
--- a/Model/Nc2ToNc3PhotoAlbum.php
+++ b/Model/Nc2ToNc3PhotoAlbum.php
@@ -113,6 +113,7 @@ class Nc2ToNc3PhotoAlbum extends Nc2ToNc3AppModel {
 		$PhotoAlbumsComponent = new PhotoAlbumsComponent(new ComponentCollection());
 		$Frame = ClassRegistry::init('Frames.Frame');
 		$Block = ClassRegistry::init('Blocks.Block');
+		$BlocksLanguage = ClassRegistry::init('Blocks.BlocksLanguage');
 		$Nc2ToNc3Frame = ClassRegistry::init('Nc2ToNc3.Nc2ToNc3Frame');
 		foreach ($nc2PhotoalbumBlocks as $nc2PhotoalbumBlock) {
 			$PhotoAlbum->begin();
@@ -131,6 +132,7 @@ class Nc2ToNc3PhotoAlbum extends Nc2ToNc3AppModel {
 				Current::write('Frame', $frame['Frame']);
 				Current::write('Room.id', $nc3RoomId);
 				$Block->create();
+				$BlocksLanguage->create();
 				$PhotoAlbumsComponent->initializeSetting();
 				$frameSetting = $FrameSetting->read();
 				$data = [

--- a/Model/Nc2ToNc3Registration.php
+++ b/Model/Nc2ToNc3Registration.php
@@ -108,6 +108,7 @@ class Nc2ToNc3Registration extends Nc2ToNc3AppModel {
 		$Nc2ToNc3Frame = ClassRegistry::init('Nc2ToNc3.Nc2ToNc3Frame');
 		$Frame = ClassRegistry::init('Frames.Frame');
 		$Block = ClassRegistry::init('Blocks.Block');
+		$BlocksLanguage = ClassRegistry::init('Blocks.BlocksLanguage');
 		foreach ($nc2Registrations as $nc2Registration) {
 			$Registration->begin();
 			try {
@@ -132,6 +133,7 @@ class Nc2ToNc3Registration extends Nc2ToNc3AppModel {
 				Current::write('Room.id', $nc3RoomId);
 				$Frame->create();
 				$Block->create();
+				$BlocksLanguage->create();
 				$Registration->createBlock($frame);
 
 				$data = $this->generateNc3RegistrationData($nc2Registration);


### PR DESCRIPTION

https://github.com/NetCommons3/NetCommons3/issues/1405

バグ修正です。
まとまったらマージします。
