### PR TITLE
fix: 移行のUserのメモリリーク改善によるパフォーマンス改善

### DIFF
--- a/Locale/nc2_to_nc3.pot
+++ b/Locale/nc2_to_nc3.pot
@@ -13,39 +13,792 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: Console/Command/Nc2ToNc3Shell.php:32
-msgid "Nc2 version is %s. It must be %s"
+#: Console/Command/Nc2ToNc3Shell.php:36
+msgid "Enter database name of nc2?"
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:14
-msgid "Input the database connection information of NetCommons2."
+#: Console/Command/Nc2ToNc3Shell.php:41
+msgid "Enter table prefix name of nc2?"
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:23
-msgid "Datasource"
+#: Console/Command/Nc2ToNc3Shell.php:69
+msgid "Enter upload path of nc2?"
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:30
-msgid "Host"
+#: Console/Command/Nc2ToNc3Shell.php:77
+msgid "Enter url of nc2 for converting link in WYSIWYG content?(ex.http://example.com/nc2)"
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:31
-msgid "Port"
+#: Console/Command/Nc2ToNc3Shell.php:85
+msgid "Enter sub directory name?(ex.\"/dirname1/dirname2\") If root is top, enter \"/\"."
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:32
+#: Model/Nc2ToNc3.php:84
 msgid "Database"
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:33
-msgid "Prefix"
+#: Model/Nc2ToNc3.php:103
+msgid "Upload file path"
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:34
-msgid "Login"
+#: Model/Nc2ToNc3.php:111
+msgid "The above Upload file path does not exist."
 msgstr ""
 
-#: View/Nc2ToNc3/migration.ctp:35
-msgid "Password"
+#: Model/Nc2ToNc3.php:119
+msgid "Base url"
+msgstr ""
+
+#: Model/Nc2ToNc3.php:120
+msgid "Input URL of NetCommons2 for converting link in WYSIWYG content."
+msgstr ""
+
+#: Model/Nc2ToNc3.php:179
+msgid "NetCommons2 version is not %s"
+msgstr ""
+
+#: Model/Nc2ToNc3.php:188
+msgid "NetCommons2 table is not found."
+msgstr ""
+
+#: Model/Nc2ToNc3.php:237
+msgid "Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3.php:309
+msgid "Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3AccessCounter.php:56
+msgid "AccessCounter Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3AccessCounter.php:65
+msgid "AccessCounter Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3AccessCounter.php:77
+msgid "  AccessCounter data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3AccessCounter.php:168
+msgid "  AccessCounter data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Announcement.php:60
+msgid "Announcement Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Announcement.php:155
+msgid "Announcement Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:57
+msgid "Bbs Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:90
+msgid "Bbs Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:103
+msgid "  Bbs data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:140
+#: Model/Nc2ToNc3Link.php:157
+#: Model/Nc2ToNc3PhotoAlbum.php:362
+#: Model/Behavior/Nc2ToNc3TopicBehavior.php:147
+msgid "%s No room ID corresponding to nc3"
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:204
+msgid "  Bbs data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:217
+msgid "  Bbs Article data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:303
+msgid "  Bbs Article data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:315
+msgid "  BbsFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Bbs.php:377
+msgid "  BbsFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:59
+msgid "Blog Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:95
+msgid "Blog Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:108
+msgid "  Blog data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:195
+msgid "  Blog data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:207
+msgid "  BlogFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:269
+msgid "  BlogFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:282
+msgid "  Blog Entry data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:373
+msgid "  Blog Entry data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:385
+#: Model/Nc2ToNc3Multidatabase.php:590
+msgid "  Content Comment data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Blog.php:454
+#: Model/Nc2ToNc3Multidatabase.php:659
+msgid "  Content Comment Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:54
+msgid "Cabinet Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:84;268
+msgid "Cabinet Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:97
+msgid "  Cabinet data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:119;296
+#: Model/Nc2ToNc3Calendar.php:274
+#: Model/Nc2ToNc3Faq.php:133;141
+#: Model/Nc2ToNc3Frame.php:247;256
+#: Model/Nc2ToNc3Iframe.php:104
+#: Model/Nc2ToNc3Link.php:340
+#: Model/Nc2ToNc3PhotoAlbum.php:125
+#: Model/Nc2ToNc3Questionnaire.php:132;140;219
+#: Model/Nc2ToNc3Quiz.php:132;140;224
+#: Model/Nc2ToNc3Registration.php:118;125;217;333
+#: Model/Nc2ToNc3Reservation.php:882
+#: Model/Nc2ToNc3Search.php:97
+#: Model/Nc2ToNc3Task.php:121;302
+#: Model/Behavior/Nc2ToNc3BbsBehavior.php:291
+#: Model/Behavior/Nc2ToNc3BlogBehavior.php:70;168
+#: Model/Behavior/Nc2ToNc3CabinetBehavior.php:57;169
+#: Model/Behavior/Nc2ToNc3CalendarBehavior.php:68;76;172;276
+#: Model/Behavior/Nc2ToNc3CircularNoticeBehavior.php:58
+#: Model/Behavior/Nc2ToNc3FaqBehavior.php:195
+#: Model/Behavior/Nc2ToNc3MenuBehavior.php:49;116;357
+#: Model/Behavior/Nc2ToNc3MultidatabaseBehavior.php:70;393
+#: Model/Behavior/Nc2ToNc3QuestionnaireBehavior.php:161;203;530;553;561
+#: Model/Behavior/Nc2ToNc3QuizBehavior.php:148;190;536;559;567
+#: Model/Behavior/Nc2ToNc3RegistrationBehavior.php:101;194;487;510;518
+#: Model/Behavior/Nc2ToNc3TopicBehavior.php:54
+#: Model/Behavior/Nc2ToNc3VideoBehavior.php:73
+msgid "%s does not migration."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:180
+msgid "  Cabinet data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:193
+msgid "  Cabinet file Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:280
+#: Model/Nc2ToNc3Registration.php:317
+#: Model/Nc2ToNc3Task.php:286
+msgid "  Frame data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:351
+#: Model/Nc2ToNc3Registration.php:391
+#: Model/Nc2ToNc3Task.php:357
+msgid "  Frame data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:68
+msgid "Calendar Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:109
+msgid "Calendar Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:121
+msgid "  CalendarPermission data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:162
+msgid "  CalendarPermission data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:175
+msgid "  CalendarFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:216
+msgid "  CalendarFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:229
+msgid "  CalendarEvent data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Calendar.php:319
+msgid "  CalendarEvent data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3CircularNotice.php:54
+msgid "CircularNotice Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3CircularNotice.php:60
+msgid "CircularNotice is not installed."
+msgstr ""
+
+#: Model/Nc2ToNc3CircularNotice.php:79
+msgid "CircularNotice Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3CircularNotice.php:92
+msgid "  CircularNoticeFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3CircularNotice.php:185
+msgid "  CircularNoticeFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3CircularNotice.php:198
+msgid "  CircularNoticeContent data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3CircularNotice.php:280
+msgid "  CircularNoticeContent data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:63
+msgid "Faq Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:69
+msgid "Faq is not installed."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:98
+msgid "Faq Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:111
+msgid "  Faq data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:205
+msgid "  Faq data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:218
+msgid "  FaqQuestion data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:286
+msgid "  FaqQuestion data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:299
+msgid "  FaqFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Faq.php:353
+msgid "  FaqFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Frame.php:60
+msgid "Frame Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Frame.php:70
+msgid "Frame Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Frame.php:119
+#: Model/Nc2ToNc3Page.php:159
+#: Model/Nc2ToNc3User.php:160
+msgid "Many error data. Please check the log. %s"
+msgstr ""
+
+#: Model/Nc2ToNc3Iframe.php:60
+msgid "Iframe Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Iframe.php:69
+msgid "Iframe Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Iframe.php:82
+msgid "  Iframe data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Iframe.php:166
+msgid "  Iframe data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Link.php:66
+msgid "Link Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Link.php:96
+msgid "Link Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Link.php:109;242
+msgid "  Link data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Link.php:229;314
+msgid "  Link data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Link.php:327
+msgid "  LinkFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Link.php:391
+msgid "  LinkFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Menu.php:59
+msgid "Menu Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Menu.php:77
+msgid "Menu Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:59
+msgid "Multidatabase Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:138
+msgid "Multidatabase Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:151
+msgid "  Multidatabase data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:286
+msgid "  Blog Multidatabase Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:298
+msgid "  MultidatabaseFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:360
+msgid "  MultidatabaseFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:373
+msgid "  MultidatabaseMetadata Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:431
+msgid "  MultidatabaseMetadata Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:444
+msgid "  Multidatabase Content Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Multidatabase.php:578
+msgid "  Multidatabase Content Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Page.php:71
+msgid "Page Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Page.php:113
+msgid "Page Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Page.php:294;300
+#: Model/Nc2ToNc3Room.php:252;322
+#: Model/Nc2ToNc3UserAttribute.php:348;375;459
+#: Model/Behavior/Nc2ToNc3UserAttributeBehavior.php:47;54;79;91;103
+msgid "%s is not migration."
+msgstr ""
+
+#: Model/Nc2ToNc3Page.php:329
+msgid "Permalink of %s is change , because of empty."
+msgstr ""
+
+#: Model/Nc2ToNc3PhotoAlbum.php:69
+msgid "PhotoAlbum Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3PhotoAlbum.php:90
+msgid "PhotoAlbum Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3PhotoAlbum.php:103
+msgid "  PhotoAlbumFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3PhotoAlbum.php:180
+msgid "  PhotoAlbumFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3PhotoAlbum.php:197
+msgid "  PhotoAlbum data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3PhotoAlbum.php:339
+msgid "  PhotoAlbum data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:70
+msgid "Questionnaire Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:100
+msgid "Questionnaire Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:112
+msgid "  Questionnaire data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:186
+msgid "  Questionnaire data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:199
+msgid "  QuestionnaireFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:269
+msgid "  QuestionnaireFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:282
+msgid "  QuestionnaireAnswerSummary data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:356
+msgid "  QuestionnaireAnswerSummary data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:372
+msgid "    QuestionnaireAnswer data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Questionnaire.php:411
+msgid "    QuestionnaireAnswer data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:70
+msgid "Quiz Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:100
+msgid "Quiz Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:112
+msgid "  Quiz data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:191
+msgid "  Quiz data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:204
+msgid "  QuizFrameSetting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:274
+msgid "  QuizFrameSetting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:287
+msgid "  QuizAnswerSummary data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:361
+msgid "  QuizAnswerSummary data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:377
+msgid "    QuizAnswer data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Quiz.php:416
+msgid "    QuizAnswer data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:63
+msgid "Registration Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:85
+msgid "Registration Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:98
+msgid "  Registration data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:185
+msgid "  Registration data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:198
+msgid "  RegistrationData data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:262
+msgid "  RegistrationAnswerSummary data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:277
+msgid "    RegistrationAnswer data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Registration.php:304
+msgid "    RegistrationAnswer data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:59
+msgid "Reservation Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:108
+msgid "Reservation Reservation start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:114
+msgid "Reservation Reservation is exist."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:155
+msgid "Reservation Reservation end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:196
+msgid "Reservation Location start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:299
+msgid "Reservation Location end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:366
+msgid "Reservation LocationsRoom start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:409
+msgid "Reservation LocationsRoom end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:471
+msgid "Reservation LocationReservable start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:503
+msgid "Reservation LocationReservable end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:514
+msgid "Reservation Rrule start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:556
+msgid "Reservation Rrule end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:632
+msgid "Reservation Event start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:674
+msgid "Reservation Event end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:775
+msgid "Reservation FrameSetting start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:783
+msgid "Reservation FrameSetting end."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:954
+msgid "  Reservation Timeframe Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Reservation.php:1002
+msgid "  ReservationTimeframe data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Room.php:84
+msgid "Room Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Room.php:138
+msgid "Room Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3RssReader.php:61
+msgid "RssReader Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3RssReader.php:70
+msgid "RssReader Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3RssReader.php:83
+msgid "  RssReader data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3RssReader.php:161
+msgid "  RssReader data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Search.php:61
+msgid "Search Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Search.php:70
+msgid "Search Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Search.php:83
+msgid "  Search data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Search.php:146
+msgid "  Search data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Task.php:58
+msgid "Task Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Task.php:85
+msgid "Task Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Task.php:98
+msgid "  Task data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Task.php:193
+msgid "  Task data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Task.php:206
+msgid "  TaskContent data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Task.php:273
+msgid "  TaskContent data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Topic.php:59
+msgid "Topic Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Topic.php:68
+msgid "Topic Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Upload.php:67;80
+#: Model/Behavior/Nc2ToNc3PhotoAlbumBehavior.php:258
+#: Model/Behavior/Nc2ToNc3WysiwygBehavior.php:169
+msgid "%s not found ."
+msgstr ""
+
+#: Model/Nc2ToNc3User.php:114
+msgid "User Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3User.php:124
+msgid "User Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3UserAttribute.php:79
+msgid "UserAttribute Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3UserAttribute.php:90
+msgid "UserAttribute Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3UserAttribute.php:394
+msgid "%s does not merge."
+msgstr ""
+
+#: Model/Nc2ToNc3Video.php:54
+msgid "Video Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Video.php:60
+msgid "Multimedia is not installed."
+msgstr ""
+
+#: Model/Nc2ToNc3Video.php:78
+msgid "Video Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Video.php:91
+msgid "  Video Setting data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Video.php:184
+msgid "  Video Setting data Migration end."
+msgstr ""
+
+#: Model/Nc2ToNc3Video.php:244
+msgid "  Video data Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Video.php:328
+msgid "  Video data Migration end."
+msgstr ""
+
+#: Model/Behavior/Nc2ToNc3PhotoAlbumBehavior.php:81
+msgid "%s does not migration. Not placed in nc2 room"
+msgstr ""
+
+#: Model/Behavior/Nc2ToNc3UserBehavior.php:53
+msgid "%s is not active.Resend approval mail."
+msgstr ""
+
+#: Model/Behavior/Nc2ToNc3UserValidationBehavior.php:86
+msgid "The require attribute of nc3 missing in nc2."
+msgstr ""
+
+#: View/Nc2ToNc3/migration.ctp:13
+msgid "Go here for the migration from NetCommons2 documentation."
 msgstr ""
 

--- a/Locale/nc2_to_nc3.pot
+++ b/Locale/nc2_to_nc3.pot
@@ -65,7 +65,7 @@ msgstr ""
 msgid "Migration start."
 msgstr ""
 
-#: Model/Nc2ToNc3.php:309
+#: Model/Nc2ToNc3.php:305
 msgid "Migration end."
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Cabinet Migration start."
 msgstr ""
 
-#: Model/Nc2ToNc3Cabinet.php:84;268
+#: Model/Nc2ToNc3Cabinet.php:84
 msgid "Cabinet Migration end."
 msgstr ""
 
@@ -189,7 +189,7 @@ msgstr ""
 #: Model/Nc2ToNc3Cabinet.php:119;296
 #: Model/Nc2ToNc3Calendar.php:274
 #: Model/Nc2ToNc3Faq.php:133;141
-#: Model/Nc2ToNc3Frame.php:247;256
+#: Model/Nc2ToNc3Frame.php:269;278
 #: Model/Nc2ToNc3Iframe.php:104
 #: Model/Nc2ToNc3Link.php:340
 #: Model/Nc2ToNc3PhotoAlbum.php:125
@@ -221,6 +221,10 @@ msgstr ""
 
 #: Model/Nc2ToNc3Cabinet.php:193
 msgid "  Cabinet file Migration start."
+msgstr ""
+
+#: Model/Nc2ToNc3Cabinet.php:268
+msgid "  Cabinet file Migration end."
 msgstr ""
 
 #: Model/Nc2ToNc3Cabinet.php:280
@@ -331,17 +335,17 @@ msgstr ""
 msgid "  FaqFrameSetting data Migration end."
 msgstr ""
 
-#: Model/Nc2ToNc3Frame.php:60
+#: Model/Nc2ToNc3Frame.php:68
 msgid "Frame Migration start."
 msgstr ""
 
-#: Model/Nc2ToNc3Frame.php:70
+#: Model/Nc2ToNc3Frame.php:78
 msgid "Frame Migration end."
 msgstr ""
 
-#: Model/Nc2ToNc3Frame.php:119
-#: Model/Nc2ToNc3Page.php:159
-#: Model/Nc2ToNc3User.php:160
+#: Model/Nc2ToNc3Frame.php:131
+#: Model/Nc2ToNc3Page.php:171
+#: Model/Nc2ToNc3User.php:172
 msgid "Many error data. Please check the log. %s"
 msgstr ""
 
@@ -385,11 +389,11 @@ msgstr ""
 msgid "  LinkFrameSetting data Migration end."
 msgstr ""
 
-#: Model/Nc2ToNc3Menu.php:59
+#: Model/Nc2ToNc3Menu.php:67
 msgid "Menu Migration start."
 msgstr ""
 
-#: Model/Nc2ToNc3Menu.php:77
+#: Model/Nc2ToNc3Menu.php:85
 msgid "Menu Migration end."
 msgstr ""
 
@@ -433,22 +437,22 @@ msgstr ""
 msgid "  Multidatabase Content Migration end."
 msgstr ""
 
-#: Model/Nc2ToNc3Page.php:71
+#: Model/Nc2ToNc3Page.php:79
 msgid "Page Migration start."
 msgstr ""
 
-#: Model/Nc2ToNc3Page.php:113
+#: Model/Nc2ToNc3Page.php:121
 msgid "Page Migration end."
 msgstr ""
 
-#: Model/Nc2ToNc3Page.php:294;300
-#: Model/Nc2ToNc3Room.php:252;322
+#: Model/Nc2ToNc3Page.php:315;321
+#: Model/Nc2ToNc3Room.php:267;337
 #: Model/Nc2ToNc3UserAttribute.php:348;375;459
 #: Model/Behavior/Nc2ToNc3UserAttributeBehavior.php:47;54;79;91;103
 msgid "%s is not migration."
 msgstr ""
 
-#: Model/Nc2ToNc3Page.php:329
+#: Model/Nc2ToNc3Page.php:350
 msgid "Permalink of %s is change , because of empty."
 msgstr ""
 
@@ -660,11 +664,11 @@ msgstr ""
 msgid "  ReservationTimeframe data Migration end."
 msgstr ""
 
-#: Model/Nc2ToNc3Room.php:84
+#: Model/Nc2ToNc3Room.php:91
 msgid "Room Migration start."
 msgstr ""
 
-#: Model/Nc2ToNc3Room.php:138
+#: Model/Nc2ToNc3Room.php:145
 msgid "Room Migration end."
 msgstr ""
 
@@ -738,11 +742,11 @@ msgstr ""
 msgid "%s not found ."
 msgstr ""
 
-#: Model/Nc2ToNc3User.php:114
+#: Model/Nc2ToNc3User.php:121
 msgid "User Migration start."
 msgstr ""
 
-#: Model/Nc2ToNc3User.php:124
+#: Model/Nc2ToNc3User.php:131
 msgid "User Migration end."
 msgstr ""
 
@@ -784,6 +788,22 @@ msgstr ""
 
 #: Model/Nc2ToNc3Video.php:328
 msgid "  Video data Migration end."
+msgstr ""
+
+#: Model/Behavior/Nc2ToNc3BaseBehavior.php:748
+#: Model/Behavior/Nc2ToNc3FrameBehavior.php:101
+#: Model/Behavior/Nc2ToNc3MenuBehavior.php:403
+#: Model/Behavior/Nc2ToNc3PageBehavior.php:204
+#: Model/Behavior/Nc2ToNc3RoomBehavior.php:307
+msgid "[%s] execution time: %s sec"
+msgstr ""
+
+#: Model/Behavior/Nc2ToNc3BaseBehavior.php:753
+#: Model/Behavior/Nc2ToNc3FrameBehavior.php:106
+#: Model/Behavior/Nc2ToNc3MenuBehavior.php:408
+#: Model/Behavior/Nc2ToNc3PageBehavior.php:209
+#: Model/Behavior/Nc2ToNc3RoomBehavior.php:312
+msgid "[%s] memory: %s MB"
 msgstr ""
 
 #: Model/Behavior/Nc2ToNc3PhotoAlbumBehavior.php:81

--- a/Model/Behavior/Nc2ToNc3BaseBehavior.php
+++ b/Model/Behavior/Nc2ToNc3BaseBehavior.php
@@ -731,7 +731,11 @@ class Nc2ToNc3BaseBehavior extends ModelBehavior {
 	}
 
 /**
- * 実行時間の計測終了
+ * 実行時間の計測終了<br>
+ * <br>
+ * Nc2ToNc3Frame, Nc2ToNc3Announcement, Nc2ToNc3Menu, Nc2ToNc3Registration<br>
+ * にざっくり実装した処、実行速度が実装前より遅くなった。<br>
+ * Nc2ToNc3User, Nc2ToNc3Room, Nc2ToNc3Pageは実行速度が早くなった。
  *
  * @param string $methodName メソッド名
  * @param float $timeStart 計測開始時間(秒)

--- a/Model/Behavior/Nc2ToNc3MenuBehavior.php
+++ b/Model/Behavior/Nc2ToNc3MenuBehavior.php
@@ -331,7 +331,7 @@ class Nc2ToNc3MenuBehavior extends Nc2ToNc3BaseBehavior {
  * Convert to Nc3MenuFrameSetting display_type.
  *
  * @param array $nc2MenuDetail Nc2MenuDetail data.
- * @return Model converted date.
+ * @return string nc2 template name.
  */
 	private function __convertDisplayType($nc2MenuDetail) {
 		$nc3DisplayType = null;

--- a/Model/Behavior/Nc2ToNc3UserBehavior.php
+++ b/Model/Behavior/Nc2ToNc3UserBehavior.php
@@ -407,4 +407,17 @@ class Nc2ToNc3UserBehavior extends Nc2ToNc3UserBaseBehavior {
 		return $Room->find('first', $query);
 	}
 
+/**
+ * 実行時間の計測終了
+ *
+ * @param string $methodName メソッド名
+ * @param float $timeStart 計測開始時間(秒)
+ * @param float $executionFlushTime この実行時間(秒)を越えたらClassRegistry::flush()
+ * @param bool $isOutputLog パフォーマンスログ出力. true:出力|false:出力しない
+ * @return void
+ * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+ */
+	protected function _executionTimeEnd($methodName, $timeStart, $executionFlushTime, $isOutputLog = false) {
+		parent::_executionTimeEnd($methodName, $timeStart, $executionFlushTime, $isOutputLog);
+	}
 }

--- a/Model/Behavior/Nc2ToNc3UserBehavior.php
+++ b/Model/Behavior/Nc2ToNc3UserBehavior.php
@@ -419,5 +419,6 @@ class Nc2ToNc3UserBehavior extends Nc2ToNc3UserBaseBehavior {
  */
 	protected function _executionTimeEnd($methodName, $timeStart, $executionFlushTime, $isOutputLog = false) {
 		parent::_executionTimeEnd($methodName, $timeStart, $executionFlushTime, $isOutputLog);
+		//parent::_executionTimeEnd($methodName, $timeStart, $executionFlushTime, true);
 	}
 }

--- a/Model/Nc2ToNc3.php
+++ b/Model/Nc2ToNc3.php
@@ -271,6 +271,10 @@ class Nc2ToNc3 extends Nc2ToNc3AppModel {
 			if (in_array(substr($migrationModelName, 8), $excludePlugins, true)) {
 				continue;
 			}
+			// 実行時間の計測開始時間
+			/* @see Nc2ToNc3BaseBehavior::executionTimeStart() */
+			$timeStart = $this->executionTimeStart();
+
 			$migrationModelName = 'Nc2ToNc3.' . $migrationModelName;
 
 			/* @var $MigrationModel Nc2ToNc3UserAttribute */
@@ -293,7 +297,9 @@ class Nc2ToNc3 extends Nc2ToNc3AppModel {
 
 			// ClassRegistryが移行で各プラグインのモデルのsave系を実行すると、処理が遅くなる & メモリ食うため、
 			// migrationModelが切り替わるタイミングで、いったん初期化する。
-			ClassRegistry::flush();
+			//ClassRegistry::flush();
+			/* @see Nc2ToNc3BaseBehavior::executionTimeEnd() */
+			$this->executionTimeEnd(__METHOD__ . ' ' . $migrationModelName, $timeStart, 0, true);
 		}
 
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Migration end.'));

--- a/Model/Nc2ToNc3.php
+++ b/Model/Nc2ToNc3.php
@@ -224,6 +224,10 @@ class Nc2ToNc3 extends Nc2ToNc3AppModel {
  * @return bool True on success
  */
 	public function migration($data) {
+		// 移行ツールは、コントローラ経由で当メソッド（migration）を呼び出してるため、システム設定＞サーバ設定＞PHP最大メモリ数(初期値:128M)
+		// がセットされる。バッチ実行がメインのため、ここでメモリを無制限に設定
+		ini_set('memory_limit', '-1');
+
 		$this->set($data);
 
 		if (!$this->validates()) {
@@ -286,6 +290,10 @@ class Nc2ToNc3 extends Nc2ToNc3AppModel {
 				$MigrationModel->calledCakeMigration) {
 				ClassRegistry::addObject('Nc2ToNc3', $this);
 			}
+
+			// ClassRegistryが移行で各プラグインのモデルのsave系を実行すると、処理が遅くなる & メモリ食うため、
+			// migrationModelが切り替わるタイミングで、いったん初期化する。
+			ClassRegistry::flush();
 		}
 
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Migration end.'));

--- a/Model/Nc2ToNc3.php
+++ b/Model/Nc2ToNc3.php
@@ -34,6 +34,13 @@ App::uses('Nc2ToNc3AppModel', 'Nc2ToNc3.Model');
 class Nc2ToNc3 extends Nc2ToNc3AppModel {
 
 /**
+ * この実行時間(秒)を越えたらClassRegistry::flush()
+ *
+ * @var float
+ */
+	public $executionFlushTime = 0;
+
+/**
  * The DataSource name for nc2
  *
  * @var string
@@ -299,7 +306,8 @@ class Nc2ToNc3 extends Nc2ToNc3AppModel {
 			// migrationModelが切り替わるタイミングで、いったん初期化する。
 			//ClassRegistry::flush();
 			/* @see Nc2ToNc3BaseBehavior::executionTimeEnd() */
-			$this->executionTimeEnd(__METHOD__ . ' ' . $migrationModelName, $timeStart, 0, true);
+			$this->executionTimeEnd(__METHOD__ . ' ' . $migrationModelName, $timeStart,
+				$this->executionFlushTime, true);
 		}
 
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Migration end.'));

--- a/Model/Nc2ToNc3Announcement.php
+++ b/Model/Nc2ToNc3Announcement.php
@@ -73,6 +73,7 @@ class Nc2ToNc3Announcement extends Nc2ToNc3AppModel {
 		$BlocksLanguage = ClassRegistry::init('Blocks.BlocksLanguage');
 		$Topic = ClassRegistry::init('Topics.Topic');
 		$Nc2ToNc3User = ClassRegistry::init('Nc2ToNc3.Nc2ToNc3User');
+
 		foreach ($nc2Announcements as $nc2Announcement) {
 			$Announcement->begin();
 
@@ -134,8 +135,6 @@ class Nc2ToNc3Announcement extends Nc2ToNc3AppModel {
 				$message = $this->getLogArgument($nc2Announcement) . "\n" .
 					var_export($Announcement->validationErrors, true);
 				$this->writeMigrationLog($message);
-
-				$Announcement->rollback();
 				continue;
 			}
 

--- a/Model/Nc2ToNc3AppModel.php
+++ b/Model/Nc2ToNc3AppModel.php
@@ -19,4 +19,10 @@
  */
 class Nc2ToNc3AppModel extends Model {
 
+/**
+ * この実行時間(秒)を越えたらClassRegistry::flush()
+ *
+ * @var float
+ */
+	public $executionFlushTime = 1.5;
 }

--- a/Model/Nc2ToNc3Bbs.php
+++ b/Model/Nc2ToNc3Bbs.php
@@ -52,6 +52,7 @@ class Nc2ToNc3Bbs extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Bbs Migration start.'));
@@ -98,7 +99,6 @@ class Nc2ToNc3Bbs extends Nc2ToNc3AppModel {
  * @return bool True on success
  * @throws Exception
  */
-
 	private function __saveNc3BbsFromNc2($nc2Bbses) {
 		$this->writeMigrationLog(__d('nc2_to_nc3', '  Bbs data Migration start.'));
 
@@ -177,7 +177,6 @@ class Nc2ToNc3Bbs extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2Bbs) . "\n" .
 						var_export($Bbs->validationErrors, true);
 					$this->writeMigrationLog($message);
-					$Bbs->rollback();
 					continue;
 				}
 

--- a/Model/Nc2ToNc3Blog.php
+++ b/Model/Nc2ToNc3Blog.php
@@ -54,6 +54,7 @@ class Nc2ToNc3Blog extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Blog Migration start.'));
@@ -157,7 +158,6 @@ class Nc2ToNc3Blog extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2Journal) . "\n" .
 						var_export($Blog->validationErrors, true);
 					$this->writeMigrationLog($message);
-					$Blog->rollback();
 					continue;
 				}
 
@@ -311,7 +311,7 @@ class Nc2ToNc3Blog extends Nc2ToNc3AppModel {
 				$nc2CategoryId = $nc2JournalPost['Nc2JournalPost']['category_id'];
 				$data['BlogEntry']['category_id'] = $Nc2ToNc3Category->getNc3CategoryId($nc3BlockId, $nc2CategoryId);
 
-				$Block = ClassRegistry::init('Blocks.Block');
+				//$Block = ClassRegistry::init('Blocks.Block');
 				$Blocks = $Block->findById($nc3BlockId, null, null, -1);
 				$nc3RoomId = $Blocks['Block']['room_id'];
 
@@ -345,7 +345,6 @@ class Nc2ToNc3Blog extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2JournalPost) . "\n" .
 						var_export($BlogEntry->validationErrors, true);
 					$this->writeMigrationLog($message);
-					$BlogEntry->rollback();
 					continue;
 				}
 

--- a/Model/Nc2ToNc3Cabinet.php
+++ b/Model/Nc2ToNc3Cabinet.php
@@ -265,7 +265,7 @@ class Nc2ToNc3Cabinet extends Nc2ToNc3AppModel {
 		Current::remove('Room.id');
 		Current::remove('Plugin.key');
 
-		$this->writeMigrationLog(__d('nc2_to_nc3', 'Cabinet Migration end.'));
+		$this->writeMigrationLog(__d('nc2_to_nc3', '  Cabinet file Migration end.'));
 		return true;
 	}
 

--- a/Model/Nc2ToNc3Calendar.php
+++ b/Model/Nc2ToNc3Calendar.php
@@ -63,6 +63,7 @@ class Nc2ToNc3Calendar extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Calendar Migration start.'));

--- a/Model/Nc2ToNc3Frame.php
+++ b/Model/Nc2ToNc3Frame.php
@@ -102,19 +102,20 @@ class Nc2ToNc3Frame extends Nc2ToNc3AppModel {
 				'Nc2Block.row_num DESC',
 				'Nc2Block.col_num DESC',
 			],
-			'limit' => $limit,
+			//'limit' => $limit,
 			'offset' => 0,
 		];
 
-		$numberOfBlocks = 0;
-		//$numberOfUsers = $Nc2Block->find('count', $query);
-		//$query['limit'] = $limit;
+		//$numberOfBlocks = 0;
+		$nc2BlockCount = 0;
+		$numberOfBlocks = $Nc2Block->find('count', $query);
+		$query['limit'] = $limit;
 		while ($nc2Blocks = $Nc2Block->find('all', $query)) {
 			if (!$this->__saveFrameFromNc2($nc2Blocks)) {
 				return false;
 			}
 
-			$numberOfBlocks += count($nc2Blocks);
+			//$numberOfBlocks += count($nc2Blocks);
 			$errorRate = round($this->__numberOfValidationError / $numberOfBlocks);
 			// 5割エラー発生で止める
 			if ($errorRate >= 0.5) {
@@ -128,6 +129,8 @@ class Nc2ToNc3Frame extends Nc2ToNc3AppModel {
 				return false;
 			}
 
+			$nc2BlockCount += count($nc2Blocks);
+			$this->writeMigrationLog('  Nc2BlockCount: ' . $nc2BlockCount);
 			$query['offset'] += $limit;
 		}
 

--- a/Model/Nc2ToNc3Frame.php
+++ b/Model/Nc2ToNc3Frame.php
@@ -55,6 +55,7 @@ class Nc2ToNc3Frame extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Frame Migration start.'));
@@ -75,6 +76,7 @@ class Nc2ToNc3Frame extends Nc2ToNc3AppModel {
  * Save Frame from Nc2 while dividing.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	private function __saveFrameFromNc2WhileDividing() {
 		$limit = 1000;
@@ -105,6 +107,8 @@ class Nc2ToNc3Frame extends Nc2ToNc3AppModel {
 		];
 
 		$numberOfBlocks = 0;
+		//$numberOfUsers = $Nc2Block->find('count', $query);
+		//$query['limit'] = $limit;
 		while ($nc2Blocks = $Nc2Block->find('all', $query)) {
 			if (!$this->__saveFrameFromNc2($nc2Blocks)) {
 				return false;
@@ -116,7 +120,9 @@ class Nc2ToNc3Frame extends Nc2ToNc3AppModel {
 			if ($errorRate >= 0.5) {
 				$this->validationErrors = [
 					'database' => [
-						__d('nc2_to_nc3', 'Many error data.Please check the log.')
+						__d('nc2_to_nc3',
+							'Many error data. Please check the log. %s',
+							['ValidationErrorCount: ' . $this->__numberOfValidationError . ' Nc2BlockCount: ' . $numberOfBlocks])
 					]
 				];
 				return false;

--- a/Model/Nc2ToNc3Menu.php
+++ b/Model/Nc2ToNc3Menu.php
@@ -54,6 +54,7 @@ class Nc2ToNc3Menu extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Menu Migration start.'));
@@ -128,8 +129,6 @@ class Nc2ToNc3Menu extends Nc2ToNc3AppModel {
 				$message = $this->getLogArgument($nc2MenuDetail) . "\n" .
 					var_export($MenuFrameSetting->validationErrors, true);
 				$this->writeMigrationLog($message);
-
-				$MenuFrameSetting->rollback();
 				return true;	// 処理を継続するためtrueを返す
 			}
 

--- a/Model/Nc2ToNc3Multidatabase.php
+++ b/Model/Nc2ToNc3Multidatabase.php
@@ -54,6 +54,7 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Multidatabase Migration start.'));
@@ -65,19 +66,19 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 			return false;
 		}
 
-		/* @var $Nc2MultidatabaseBlock AppModel */
-		$Nc2MultidatabaseBlock = $this->getNc2Model('multidatabase_block');
-		$nc2MultidatabaseBlocks = $Nc2MultidatabaseBlock->find('all');
-		if (!$this->__saveNc3MultidatabaseFrameSettingFromNc2($nc2MultidatabaseBlocks)) {
+		/* @var $Nc2MultidbBlock AppModel */
+		$Nc2MultidbBlock = $this->getNc2Model('multidatabase_block');
+		$nc2MultidbBlocks = $Nc2MultidbBlock->find('all');
+		if (!$this->__saveNc3MultidatabaseFrameSettingFromNc2($nc2MultidbBlocks)) {
 			return false;
 		}
 
-		$Nc2MultidatabaseMetadata = $this->getNc2Model('multidatabase_metadata');
+		$Nc2MultidbMetadata = $this->getNc2Model('multidatabase_metadata');
 		// col_noをうめるためにmultidatabase_id
-		$nc2MultidatabaseMetadatas = $Nc2MultidatabaseMetadata->find('all', [
+		$nc2MultidbMetadatas = $Nc2MultidbMetadata->find('all', [
 			'order' => 'multidatabase_id ASC'
 		]);
-		if (!$this->__saveNc3MultidatabaseMetadataFromNc2($nc2MultidatabaseMetadatas)) {
+		if (!$this->__saveNc3MultidatabaseMetadataFromNc2($nc2MultidbMetadatas)) {
 			return false;
 		}
 
@@ -146,7 +147,6 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
  * @return bool True on success
  * @throws Exception
  */
-
 	private function __saveNc3MultidatabaseFromNc2($nc2Multidatabases) {
 		$this->writeMigrationLog(__d('nc2_to_nc3', '  Multidatabase data Migration start.'));
 
@@ -200,7 +200,6 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2Multidatabase) . "\n" .
 						var_export($Multidatabase->validationErrors, true);
 					$this->writeMigrationLog($message);
-					$Multidatabase->rollback();
 					continue;
 				}
 
@@ -228,7 +227,6 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($data) . "\n" .
 						var_export($Multidatabase->validationErrors, true);
 					$this->writeMigrationLog($message);
-					$Multidatabase->rollback();
 					continue;
 				}
 
@@ -251,7 +249,6 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($data) . "\n" .
 						var_export($Multidatabase->validationErrors, true);
 					$this->writeMigrationLog($message);
-					$Multidatabase->rollback();
 					continue;
 				}
 
@@ -290,21 +287,21 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 /**
  * Save BlogFrameSetting from Nc2.
  *
- * @param array $nc2MultidatabaseBlocks Nc2ournalBlock data.
+ * @param array $nc2MultidbBlocks Nc2MultidatabaseBlock data.
  * @return bool True on success
  * @throws Exception
  */
-	private function __saveNc3MultidatabaseFrameSettingFromNc2($nc2MultidatabaseBlocks) {
+	private function __saveNc3MultidatabaseFrameSettingFromNc2($nc2MultidbBlocks) {
 		$this->writeMigrationLog(__d('nc2_to_nc3', '  MultidatabaseFrameSetting data Migration start.'));
 
 		/* @var $MultidbFrameSetting BlogFrameSetting */
 		/* @var $Frame Frame */
 		$MultidbFrameSetting = ClassRegistry::init('Multidatabases.MultidatabaseFrameSetting');
 		$Frame = ClassRegistry::init('Frames.Frame');
-		foreach ($nc2MultidatabaseBlocks as $nc2MultidatabaseBlock) {
+		foreach ($nc2MultidbBlocks as $nc2MultidbBlock) {
 			$MultidbFrameSetting->begin();
 			try {
-				$data = $this->generateNc3MultidatabaseFrameSettingData($nc2MultidatabaseBlock);
+				$data = $this->generateNc3MultidatabaseFrameSettingData($nc2MultidbBlock);
 				if (!$data) {
 					$MultidbFrameSetting->rollback();
 					continue;
@@ -315,7 +312,7 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 					// print_rはPHPMD.DevelopmentCodeFragmentに引っかかった。
 					// var_exportは大丈夫らしい。。。
 					// @see https://phpmd.org/rules/design.html
-					$message = $this->getLogArgument($nc2MultidatabaseBlock) . "\n" .
+					$message = $this->getLogArgument($nc2MultidbBlock) . "\n" .
 						var_export($MultidbFrameSetting->validationErrors, true);
 					$this->writeMigrationLog($message);
 
@@ -327,7 +324,7 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 					// print_rはPHPMD.DevelopmentCodeFragmentに引っかかった。
 					// var_exportは大丈夫らしい。。。
 					// @see https://phpmd.org/rules/design.html
-					$message = $this->getLogArgument($nc2MultidatabaseBlock) . "\n" .
+					$message = $this->getLogArgument($nc2MultidbBlock) . "\n" .
 						var_export($MultidbFrameSetting->validationErrors, true);
 					$this->writeMigrationLog($message);
 
@@ -335,7 +332,7 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 					continue;
 				}
 
-				$nc2BlockId = $nc2MultidatabaseBlock['Nc2MultidatabaseBlock']['block_id'];
+				$nc2BlockId = $nc2MultidbBlock['Nc2MultidatabaseBlock']['block_id'];
 				$idMap = [
 					$nc2BlockId => $MultidbFrameSetting->id
 				];
@@ -443,23 +440,20 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 	private function __saveNc3MultidbContentFromNc2($nc2MultidbContents) {
 		$this->writeMigrationLog(__d('nc2_to_nc3', '  Multidatabase Content Migration start.'));
 
-		/* @var $DbContent BlogEntry */
+		/* @var $DbContent MultidatabaseContent */
 		/* @var $Nc2ToNc3Category Nc2ToNc3Category */
 		$DbContent = ClassRegistry::init('Multidatabases.MultidatabaseContent');
 
 		Current::write('Plugin.key', 'multidatabases');
 
-		//$Nc2Journal = $this->getNc2Model('journal');
-		$BlocksLanguage = ClassRegistry::init('Blocks.BlocksLanguage');
-		$Block = ClassRegistry::init('Blocks.Block');
+		//$BlocksLanguage = ClassRegistry::init('Blocks.BlocksLanguage');
+		//$Block = ClassRegistry::init('Blocks.Block');
 		//$Topic = ClassRegistry::init('Topics.Topic');
-
-		$Nc2MultidbFile = $this->getNc2Model('multidatabase_file');
-
+		//$Nc2MultidbFile = $this->getNc2Model('multidatabase_file');
 		$AuthorizationKey = ClassRegistry::init('AuthorizationKeys.AuthorizationKey');
 		$UploadFile = ClassRegistry::init('Files.UploadFile');
-
 		$Like = ClassRegistry::init('Likes.Like');
+
 		foreach ($nc2MultidbContents as $nc2MultidbContent) {
 			$DbContent->begin();
 			//$DbContent->Behaviors->disable('Attachment');
@@ -509,7 +503,6 @@ class Nc2ToNc3Multidatabase extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2MultidbContent) . "\n" .
 						var_export($DbContent->validationErrors, true);
 					$this->writeMigrationLog($message);
-					$DbContent->rollback();
 					continue;
 				}
 

--- a/Model/Nc2ToNc3Page.php
+++ b/Model/Nc2ToNc3Page.php
@@ -120,6 +120,7 @@ class Nc2ToNc3Page extends Nc2ToNc3AppModel {
  *
  * @param string $nc2LangDirName Nc2Page lang_dirname.
  * @return bool True on success.
+ * @throws Exception
  */
 	private function __savePageFromNc2WhileDividing($nc2LangDirName) {
 		$limit = 1000;
@@ -144,6 +145,8 @@ class Nc2ToNc3Page extends Nc2ToNc3AppModel {
 		$this->changeNc3CurrentLanguage($nc2LangDirName);
 
 		$numberOfPages = 0;
+		//$numberOfUsers = $Nc2Page->find('count', $query);
+		//$query['limit'] = $limit;
 		while ($nc2Pages = $Nc2Page->find('all', $query)) {
 			if (!$this->__savePageFromNc2($nc2Pages)) {
 				$this->restoreNc3CurrentLanguage();
@@ -156,7 +159,9 @@ class Nc2ToNc3Page extends Nc2ToNc3AppModel {
 			if ($errorRate >= 0.5 && $numberOfPages > 100) {
 				$this->validationErrors = [
 					'database' => [
-						__d('nc2_to_nc3', 'Many error data.Please check the log.')
+						__d('nc2_to_nc3',
+							'Many error data. Please check the log. %s',
+							['ValidationErrorCount: ' . $this->__numberOfValidationError . ' Nc2PagesCount: ' . $numberOfPages])
 					]
 				];
 

--- a/Model/Nc2ToNc3Questionnaire.php
+++ b/Model/Nc2ToNc3Questionnaire.php
@@ -65,6 +65,7 @@ class Nc2ToNc3Questionnaire extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Questionnaire Migration start.'));
@@ -117,6 +118,7 @@ class Nc2ToNc3Questionnaire extends Nc2ToNc3AppModel {
 		$Questionnaire = ClassRegistry::init('Questionnaires.Questionnaire');
 		$Nc2QBlock = $this->getNc2Model('questionnaire_block');
 		$Frame = ClassRegistry::init('Frames.Frame');
+
 		foreach ($nc2Questionnaires as $nc2Questionnaire) {
 			$Questionnaire->begin();
 			try {
@@ -159,8 +161,6 @@ class Nc2ToNc3Questionnaire extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2Questionnaire) . "\n" .
 						var_export($Questionnaire->validationErrors, true);
 					$this->writeMigrationLog($message);
-
-					$Questionnaire->rollback();
 					continue;
 				}
 
@@ -204,6 +204,7 @@ class Nc2ToNc3Questionnaire extends Nc2ToNc3AppModel {
 		$QFrameSetting = ClassRegistry::init('Questionnaires.QuestionnaireFrameSetting');
 		$Nc2ToNc3Frame = ClassRegistry::init('Nc2ToNc3.Nc2ToNc3Frame');
 		$Block = ClassRegistry::init('Blocks.Block');
+
 		foreach ($nc2QBlocks as $nc2QBlock) {
 			$QFrameSetting->begin();
 			try {
@@ -286,6 +287,7 @@ class Nc2ToNc3Questionnaire extends Nc2ToNc3AppModel {
 		$QAnswerSummary = ClassRegistry::init('Questionnaires.QuestionnaireAnswerSummary');
 		$Questionnaire = ClassRegistry::init('Questionnaires.Questionnaire');
 		$nc2PreviousQId = null;
+
 		foreach ($nc2QSummaries as $nc2QSummary) {
 			$QAnswerSummary->begin();
 			try {

--- a/Model/Nc2ToNc3Quiz.php
+++ b/Model/Nc2ToNc3Quiz.php
@@ -65,6 +65,7 @@ class Nc2ToNc3Quiz extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Quiz Migration start.'));
@@ -159,8 +160,6 @@ class Nc2ToNc3Quiz extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2Quiz) . "\n" .
 						var_export($Quiz->validationErrors, true);
 					$this->writeMigrationLog($message);
-
-					$Quiz->rollback();
 					continue;
 				}
 
@@ -209,6 +208,7 @@ class Nc2ToNc3Quiz extends Nc2ToNc3AppModel {
 		$QFrameSetting = ClassRegistry::init('Quizzes.QuizFrameSetting');
 		$Nc2ToNc3Frame = ClassRegistry::init('Nc2ToNc3.Nc2ToNc3Frame');
 		$Block = ClassRegistry::init('Blocks.Block');
+
 		foreach ($nc2QBlocks as $nc2QBlock) {
 			$QFrameSetting->begin();
 			try {
@@ -290,6 +290,7 @@ class Nc2ToNc3Quiz extends Nc2ToNc3AppModel {
 		/* @var $Quiz Quiz */
 		$QAnswerSummary = ClassRegistry::init('Quizzes.QuizAnswerSummary');
 		$Quiz = ClassRegistry::init('Quizzes.Quiz');
+
 		$nc2PreviousQId = null;
 		foreach ($nc2QSummaries as $nc2QSummary) {
 			$QAnswerSummary->begin();

--- a/Model/Nc2ToNc3Registration.php
+++ b/Model/Nc2ToNc3Registration.php
@@ -58,6 +58,7 @@ class Nc2ToNc3Registration extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Registration Migration start.'));
@@ -158,8 +159,6 @@ class Nc2ToNc3Registration extends Nc2ToNc3AppModel {
 					$message = $this->getLogArgument($nc2Registration) . "\n" .
 						var_export($Registration->validationErrors, true);
 					$this->writeMigrationLog($message);
-
-					$Registration->rollback();
 					continue;
 				}
 
@@ -274,7 +273,7 @@ class Nc2ToNc3Registration extends Nc2ToNc3AppModel {
  * @throws Exception
  */
 	private function __saveRegistrationAnswerFromNc2($nc2ItemData, $nc3Registration, $nc3Summary) {
-		$this->writeMigrationLog(__d('nc2_to_nc3', '    RegistrationAnswer data Migration start.'));
+		//$this->writeMigrationLog(__d('nc2_to_nc3', '    RegistrationAnswer data Migration start.'));
 
 		/* @var $RegistrationAnswer RegistrationAnswer */
 		$RegistrationAnswer = ClassRegistry::init('Registrations.RegistrationAnswer');
@@ -301,7 +300,7 @@ class Nc2ToNc3Registration extends Nc2ToNc3AppModel {
 			throw $ex;
 		}
 
-		$this->writeMigrationLog(__d('nc2_to_nc3', '    RegistrationAnswer data Migration end.'));
+		//$this->writeMigrationLog(__d('nc2_to_nc3', '    RegistrationAnswer data Migration end.'));
 
 		return true;
 	}
@@ -366,10 +365,10 @@ class Nc2ToNc3Registration extends Nc2ToNc3AppModel {
 					// @see https://phpmd.org/rules/design.html
 					$message = $this->getLogArgument($nc2RBlocks) . "\n" .
 						var_export($Frame->validationErrors, true);
-						$this->writeMigrationLog($message);
+					$this->writeMigrationLog($message);
 
-						$Frame->rollback();
-						continue;
+					$Frame->rollback();
+					continue;
 				}
 
 				$idMap = [

--- a/Model/Nc2ToNc3Room.php
+++ b/Model/Nc2ToNc3Room.php
@@ -79,6 +79,7 @@ class Nc2ToNc3Room extends Nc2ToNc3AppModel {
  * Migration method.
  *
  * @return bool True on success.
+ * @throws Exception
  */
 	public function migrate() {
 		$this->writeMigrationLog(__d('nc2_to_nc3', 'Room Migration start.'));
@@ -168,6 +169,10 @@ class Nc2ToNc3Room extends Nc2ToNc3AppModel {
 		$RolesRoomsUser = ClassRegistry::init('Rooms.RolesRoomsUser');
 
 		foreach ($nc2Pages as $nc2Page) {
+			// 実行時間の計測開始時間
+			/* @see Nc2ToNc3BaseBehavior::executionTimeStart() */
+			$timeStart = $this->executionTimeStart();
+
 			/*
 			if (!$this->isMigrationRow($nc2User)) {
 				continue;
@@ -178,6 +183,7 @@ class Nc2ToNc3Room extends Nc2ToNc3AppModel {
 				$data = $this->__generateNc3Data($nc2Page);
 				if (!$data) {
 					$Room->rollback();
+					$this->executionTimeEnd(__METHOD__, $timeStart, $this->executionFlushTime);
 					continue;
 				}
 
@@ -191,7 +197,7 @@ class Nc2ToNc3Room extends Nc2ToNc3AppModel {
 						var_export($Room->validationErrors, true);
 					$this->writeMigrationLog($message);
 
-					$Room->rollback();
+					$this->executionTimeEnd(__METHOD__, $timeStart, $this->executionFlushTime);
 					continue;
 				}
 				$nc2PageId = $nc2Page['Nc2Page']['page_id'];
@@ -205,12 +211,14 @@ class Nc2ToNc3Room extends Nc2ToNc3AppModel {
 				if (!$RolesRoomsUser->saveRolesRoomsUsersForRooms($data)) {
 					// RolesRoomsUser::saveRolesRoomsUsersForRoomsではreturn falseなし
 					$Room->rollback();
+					$this->executionTimeEnd(__METHOD__, $timeStart, $this->executionFlushTime);
 					continue;
 				}
 
 				$nc2RoomId = $nc2Page['Nc2Page']['room_id'];
 				if ($this->getMap($nc2RoomId)) {
 					$Room->commit();
+					$this->executionTimeEnd(__METHOD__, $timeStart, $this->executionFlushTime);
 					continue;
 				}
 
@@ -220,6 +228,7 @@ class Nc2ToNc3Room extends Nc2ToNc3AppModel {
 				$this->saveMap('Room', $idMap);
 
 				$Room->commit();
+				$this->executionTimeEnd(__METHOD__, $timeStart, $this->executionFlushTime);
 
 			} catch (Exception $ex) {
 				// NetCommonsAppModel::rollback()でthrowされるので、以降の処理は実行されない

--- a/Model/Nc2ToNc3User.php
+++ b/Model/Nc2ToNc3User.php
@@ -154,6 +154,7 @@ class Nc2ToNc3User extends Nc2ToNc3AppModel {
 
 		// NC2ユーザ件数
 		//$numberOfUsers = 0;
+		$nc2UserCount = 0;
 		$numberOfUsers = $Nc2User->find('count', $query);
 
 		$query['limit'] = $limit;
@@ -176,6 +177,8 @@ class Nc2ToNc3User extends Nc2ToNc3AppModel {
 				return false;
 			}
 
+			$nc2UserCount += count($nc2Users);
+			$this->writeMigrationLog('  Nc2UserCount: ' . $nc2UserCount);
 			$query['offset'] += $limit;
 		}
 

--- a/Model/Nc2ToNc3User.php
+++ b/Model/Nc2ToNc3User.php
@@ -46,13 +46,6 @@ App::uses('Nc2ToNc3AppModel', 'Nc2ToNc3.Model');
 class Nc2ToNc3User extends Nc2ToNc3AppModel {
 
 /**
- * この実行時間(秒)を越えたらClassRegistry::flush()
- *
- * @var float
- */
-	public $executionFlushTime = 1.5;
-
-/**
  * Custom database table name, or null/false if no table association is desired.
  *
  * @var string


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1486

パフォーマンス改善のプルリクエストです。
マージしようと思ってます。

### 修正内容

* 移行のUserのメモリリーク改善によるパフォーマンス改善
* 言語ファイルが更新されてなかったため再作成
* バリデーションエラー5割で停止のメッセージ修正
* 実行時、メモリ無制限を設定

