### PR TITLE
Revert "fix: Nc2ToNc3モデルではClassRegistry::flushさせない"

### DIFF
--- a/Model/Nc2ToNc3.php
+++ b/Model/Nc2ToNc3.php
@@ -35,13 +35,10 @@ class Nc2ToNc3 extends Nc2ToNc3AppModel {
 
 /**
  * この実行時間(秒)を越えたらClassRegistry::flush()
- * 実行したら、お知らせ等の移行でupload_idなしのエラーが出たため、ClassRegistry::flushさせない数字にする。
- * [エラー内容]
- * Nc2Upload upload_id:999 not found . - announcement/9999.png : Nc2ToNc3Upload on line 88
  *
  * @var float
  */
-	public $executionFlushTime = 99999999;
+	public $executionFlushTime = 0;
 
 /**
  * The DataSource name for nc2

--- a/Model/Nc2ToNc3Questionnaire.php
+++ b/Model/Nc2ToNc3Questionnaire.php
@@ -371,7 +371,7 @@ class Nc2ToNc3Questionnaire extends Nc2ToNc3AppModel {
  * @throws Exception
  */
 	private function __saveQuestionnaireAnswerFromNc2($nc2QSummary, $nc3QAnswerSummary, $nc3Questionnaire, $questionMap) {
-		//$this->writeMigrationLog(__d('nc2_to_nc3', '    QuestionnaireAnswer data Migration start.'));
+		$this->writeMigrationLog(__d('nc2_to_nc3', '    QuestionnaireAnswer data Migration start.'));
 
 		/* @var $Nc2QAnswer AppModel */
 		$Nc2QAnswer = $this->getNc2Model('questionnaire_answer');
@@ -410,7 +410,7 @@ class Nc2ToNc3Questionnaire extends Nc2ToNc3AppModel {
 			throw $ex;
 		}
 
-		//$this->writeMigrationLog(__d('nc2_to_nc3', '    QuestionnaireAnswer data Migration end.'));
+		$this->writeMigrationLog(__d('nc2_to_nc3', '    QuestionnaireAnswer data Migration end.'));
 
 		return true;
 	}


### PR DESCRIPTION
元に戻す
https://github.com/NetCommons3/NetCommons3/issues/1486